### PR TITLE
Docs/env var documentation issue 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Additional platform builds may be added in the future as cross-platform support 
 
 Built artifacts are output to the `dist/` directory.
 
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `SOTERIOS_DISABLE_GPU=1`   | Setting this will disable GPU acceleration (which is enabled by default), to force full software rendering. Set this if rendering glitches or crashes occur related to GPU drivers.
+| `SOTERIOS_USERDATA=<path>` | Allows for specifying a custom path to override the default user data directory (%APPDATA%\Soterios). This may be useful for running isolating instances to retain results.
+
+
 ---
 
 ## API Notes

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Built artifacts are output to the `dist/` directory.
 | `SOTERIOS_DISABLE_GPU=1`   | Setting this will disable GPU acceleration (which is enabled by default), to force full software rendering. Set this if rendering glitches or crashes occur related to GPU drivers.
 | `SOTERIOS_USERDATA=<path>` | Allows for specifying a custom path to override the default user data directory (%APPDATA%\Soterios). This may be useful for running isolating instances to retain results.
 
+In order to utilize these environment variables during runtime, the start command can be modified as followed: `set SOTERIOS_DISABLE_GPU=1 && npm start`.
 
 ---
 


### PR DESCRIPTION
This PR addresses the documentation request outlined in Issue #29. The following were added:

* Environment Variables section added in the README.md file
* Section exists as a subsection under Development Setup
* Environment variables SOTERIOS_DISABLE_GPU and SOTERIOS_USERDATA were defined, with functionality cross-referenced with `src/main/main.js`
* Instructions included to modify start command for utilizing effects of described environment variables.

Closes chrisriv10/Soterios#29