### PR TITLE
feat: add Midnight color theme

### DIFF
--- a/src/ui/css/style.css
+++ b/src/ui/css/style.css
@@ -130,6 +130,22 @@
   --accent-danger: #ff8fa0;
 }
 
+:root[data-theme="midnight"] {
+  --bg-base: #0a0e1a;
+  --bg-surface: rgba(14, 22, 42, 0.88);
+  --bg-surface-hover: rgba(22, 34, 62, 0.95);
+  --glass-border: rgba(96, 165, 250, 0.18);
+  --body-gradient: var(--bg-base);
+  --text-main: #e8edf5;
+  --text-muted: #94a3c4;
+  --accent-primary: #38bdf8;
+  --accent-primary-dark: #0ea5e9;
+  --accent-primary-glow: rgba(56, 189, 248, 0.22);
+  --accent-success: #2dd4bf;
+  --accent-warning: #fbbf24;
+  --accent-danger: #f87171;
+}
+
 body {
   background-color: var(--bg-base);
   color: var(--text-main);

--- a/src/ui/js/api.js
+++ b/src/ui/js/api.js
@@ -5,7 +5,7 @@ const Api = {
       'black-red': 'crimson',
       'black-green': 'terminal'
     }[theme] || theme;
-    const allowed = ['dark', 'light', 'ocean', 'emerald', 'sunset', 'violet', 'crimson', 'terminal'];
+    const allowed = ['dark', 'light', 'ocean', 'emerald', 'sunset', 'violet', 'crimson', 'terminal', 'midnight'];
     const finalTheme = allowed.includes(normalized) ? normalized : 'dark';
     document.documentElement.setAttribute('data-theme', finalTheme);
     document.documentElement.style.setProperty('--theme-name', finalTheme);

--- a/src/ui/js/pages/settings.js
+++ b/src/ui/js/pages/settings.js
@@ -89,6 +89,7 @@ window.Pages.settings = {
               <option value="violet" ${settings.ui?.theme === 'violet' ? 'selected' : ''}>Violet</option>
               <option value="crimson" ${settings.ui?.theme === 'crimson' ? 'selected' : ''}>Crimson</option>
               <option value="terminal" ${settings.ui?.theme === 'terminal' ? 'selected' : ''}>Terminal</option>
+              <option value="midnight" ${settings.ui?.theme === 'midnight' ? 'selected' : ''}>Midnight</option>
             </select>
           </div>
           <div class="toggle-desc" style="margin-bottom:12px;">Choose a palette for the full app experience.</div>


### PR DESCRIPTION
## Summary

Closes #47 — Adds the Midnight color theme.

## Details

This PR implements the **Midnight** theme:
1. **style.css**: Added a new `:root[data-theme="midnight"]` block with a sleek, high-contrast, modern dark blue/navy palette:
   - Deep navy background (`#0a0e1a`)
   - Cool translucent blue-black surfaces (`rgba(14, 22, 42, 0.88)` and `rgba(22, 34, 62, 0.95)`)
   - Electric cyan accents (`#38bdf8`) and glow
   - Consistent teal success, amber warning, and red danger colors
2. **api.js**: Added `midnight` to the allowed themes array.
3. **settings.js**: Added the Midnight option to the Settings theme dropdown select menu.