### PR TITLE
refactor: extract BlocklistService refresh interval into constant (#27)

### DIFF
--- a/src/security/BlocklistService.js
+++ b/src/security/BlocklistService.js
@@ -5,11 +5,14 @@
 
 const https = require('https');
 
+/** How often (ms) blocklists are refreshed from their upstream sources. */
+const BLOCKLIST_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
+
 class BlocklistService {
   constructor(db) {
     this.db = db;
     this.blocklists = new Map();
-    this.refreshInterval = 12 * 60 * 60 * 1000; // 12 hours
+    this.refreshInterval = BLOCKLIST_REFRESH_INTERVAL_MS;
 
     // Free public blocklist sources
     this.sources = [


### PR DESCRIPTION
## Summary
Extract the inline magic-number refresh interval (`12 * 60 * 60 * 1000`) in `BlocklistService` into a module-level constant `BLOCKLIST_REFRESH_INTERVAL_MS`.

## Motivation
Resolves #27. Replaces a magic number with a clearly named, documented constant so the value is centralized and self-describing.

## Testing
Behavior unchanged (same 12-hour interval). Validated with a syntax/type check.

Closes #27
