### PR TITLE
fix(scan): prevent duplicate notifications and report spam

### DIFF
--- a/src/main/ipcHandlers.js
+++ b/src/main/ipcHandlers.js
@@ -252,9 +252,16 @@ function registerIpcHandlers(mainWindow, services) {
 
   // -- Scanning Engine --
   ipcMain.handle('scan:status', () => {
+    const scanStatus = scanEngine.getStatus();
+    if (scanStatus.currentScan && scanStatus.currentScan.scanType === 'folderwatch') {
+      return {
+        engine: clamEngine.getStatus(),
+        scan: { isScanning: false, currentScan: null }
+      };
+    }
     return {
       engine: clamEngine.getStatus(),
-      scan: scanEngine.getStatus()
+      scan: scanStatus
     };
   });
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -76,7 +76,7 @@ let mainWindow;
 let splashWindow;
 let splashTimeoutId;
 let dbRef; // set once the database is created in app.whenReady() below, so
-           // showNotification (defined before that point) can check settings
+// showNotification (defined before that point) can check settings
 let currentUiTheme = 'dark';
 
 function logLine(level, message, meta) {
@@ -569,15 +569,26 @@ app.whenReady().then(async () => {
   registerIpcHandlers(mainWindow, services);
   sendSplashProgress(12, 'Registering services...');
 
+  //Clean up any existing listeners first to prevent dublicates duriing hot-relaod
+  eventBus._listeners.delete('scan:progress');
+  eventBus._listeners.delete('scan:complete');
+
   // Forward scan progress events from EventBus to renderer
   const announcedProgress = new Set();
   eventBus.on('scan:progress', (data) => {
+
+    //Ignore progress notifications for definitions updates and custom/watcher scans
+    const scanType = data.scanType || data.report?.scanType;
+    if(scanType === 'folderwatch') return;
+
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('scan:progress', data);
     }
     if (!data || typeof data.pct !== 'number') return;
     if (dbRef && !dbRef.getSetting('feature.scanNotifications', true)) return;
-    if (data.scanType === 'definitions') return;
+
+    if(scanType === 'definitions' || scanType === 'custom') return;
+
     const milestone = [0, 25, 50, 75].find((value) => data.pct >= value && !announcedProgress.has(value));
     if (milestone !== undefined) {
       announcedProgress.add(milestone);
@@ -588,10 +599,16 @@ app.whenReady().then(async () => {
 
   // Forward scan complete events to renderer
   eventBus.on('scan:complete', (data) => {
+    const scanType = data.scanType || data.report?.scanType;
+    if(scanType === 'folderwatch') return;
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('scan:complete', data);
     }
     announcedProgress.clear();
+
+    //Ignore notification and report for custom/watcher scans
+    if(scanType === 'custom') return;
+
     let label;
     let body;
     let level;
@@ -619,7 +636,14 @@ app.whenReady().then(async () => {
     (async () => {
       try {
         if (!db.getSetting('feature.autoReports', true)) return;
+
+        const scanType = data.scanType || data.report?.scanType;
+        const isCanceled = data.status === 'canceled' || data.report?.status === 'canceled';
+
+        //skip reports for cancelled scans. definition updates, and cutom/watcher scans
+        if (isCanceled || (scanType !== 'quick' && scanType !== 'full')) return;
         logLine('info', 'Generating scan report...');
+
         const result = await toolRegistry.run('generate-security-report', { version: app.getVersion() }, { toolRegistry, db, log: logLine });
         logLine('info', 'Scan report ' + (result.ok ? 'generated' : 'failed: ' + (result.error || 'unknown')));
       } catch (err) {
@@ -827,9 +851,9 @@ app.whenReady().then(async () => {
     };
     const networkStatsTimer = setInterval(sampleNetworkStats, 30_000);
     if (typeof networkStatsTimer.unref === 'function') networkStatsTimer.unref();
-    sampleNetworkStats().catch(() => {});
+    sampleNetworkStats().catch(() => { });
     const pruneTimer = setInterval(() => {
-      try { db.pruneNetworkStats(7); } catch (_) {}
+      try { db.pruneNetworkStats(7); } catch (_) { }
     }, 60 * 60_000);
     if (typeof pruneTimer.unref === 'function') pruneTimer.unref();
     try {

--- a/src/security/FolderWatcher.js
+++ b/src/security/FolderWatcher.js
@@ -130,7 +130,13 @@ class FolderWatcher {
         const filePath = this._queue.shift();
         this._scannedRecently.set(filePath, Date.now());
         try {
-          const result = await this.scanEngine.runCustomScan([filePath]);
+          let result;
+          if(typeof this.scanEngine.runScan === 'function') {
+            result = await this.scanEngine.runScan('folderwatch', [filePath], 'Folder watch scan starting...');
+          } else {
+            result = await this.scanEngine.runCustomScan([filePath]);
+          }
+
           if (result && result.error) continue;
           const threats = (result && result.threatsFound) || 0;
           if (threats > 0) {


### PR DESCRIPTION
### Overview
This PR resolves Issue #79 by fixing duplicate notifications/logs during development hot-reloads and preventing background tasks (canceled scans, definition updates, and folder-watcher scans) from spamming the user with automatic PDF/HTML reports and notifications.

### Proposed Changes

1. **Guard Against Hot-Reload Duplicates:**
   - Added EventBus listener cleanup in `src/main/main.js` before registering `scan:progress` and `scan:complete` listeners. This prevents duplicate event handlers from accumulating when the app reloads during development.

2. **Differentiate Watcher Scans:**
   - Modified `src/security/FolderWatcher.js` to run its background scans under a distinct `'folderwatch'` scan type instead of `'custom'`.

3. **Silence Background Scans:**
   - Added logic in `src/main/main.js` to intercept and ignore `'folderwatch'` events so they do not send progress/complete alerts, write logs, or show toast notifications.
   - Updated the `scan:status` IPC handler in `src/main/ipcHandlers.js` to hide active `'folderwatch'` background scans from the frontend, ensuring the Malware Scan buttons do not lock up or display "Scanning..." on application startup.

4. **Filter Auto-Reports:**
   - Updated `scan:complete` report generation check to ensure reports are only created for completed `'quick'` and `'full'` scans, skipping canceled scans and background tasks.

### Verification Results
- Verified that canceled scans do not generate reports or logs.
- Verified that folder-watcher scans run silently in the background and no longer lock the dashboard/scanner buttons or show toast notifications.
- All unit tests pass successfully (excluding the Windows-specific permission check test).

Closes #79
