### PR TITLE
fix(feed): URLhaus v1 endpoint

### DIFF
--- a/.github/workflows/threat-feed.yml
+++ b/.github/workflows/threat-feed.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           test -n "$URLHAUS_AUTH_KEY"
           curl --fail --silent --show-error --retry 3 "https://hole.cert.pl/domains/v2/domains.txt" -o certpl-domains.txt
-          curl --fail --silent --show-error --retry 3 -H "Auth-Key: ${URLHAUS_AUTH_KEY}" "https://urlhaus-api.abuse.ch/v2/urls/recent/" -o urlhaus.json
+          curl --fail --silent --show-error --retry 3 -H "Auth-Key: ${URLHAUS_AUTH_KEY}" "https://urlhaus-api.abuse.ch/v1/urls/recent/" -o urlhaus.json
       - name: Normalize, shard, hash, and sign
         env:
           THREAT_FEED_PRIVATE_KEY: ${{ secrets.THREAT_FEED_PRIVATE_KEY }}


### PR DESCRIPTION
URLhaus v2 recent endpoint returns 404; v1 is the documented path. First smoke run confirmed the pipeline reached the feed fetch step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatically generated threat feed containing normalized, deduplicated phishing and malicious URL indicators.
  * Added signed feed manifests with metadata, integrity hashes, expiration details, and attribution information.
  * Published the threat feed to a hosted destination on a scheduled or manually triggered basis.
  * Added validation and safeguards for inactive indicators, required credentials, malformed inputs, and feed size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->