### PR TITLE
Complete pr 104

### DIFF
--- a/src/core/pathSafety.js
+++ b/src/core/pathSafety.js
@@ -59,10 +59,8 @@ function defaultMutationRoots() {
   ]);
 }
 
-function hasWindowsShortNameSegment(value) {
-  return String(value || '')
-    .split(/[\\/]+/)
-    .some((segment) => /^[^\\/:*?"<>|]{1,6}~\d(?:\..*)?$/i.test(segment));
+function isWindowsShortNameSegment(value) {
+  return /^[^\\/:*?"<>|]{1,6}~\d(?:\..*)?$/i.test(String(value || ''));
 }
 
 function isWindowsShortNameAliasPath(candidate, real) {
@@ -70,9 +68,14 @@ function isWindowsShortNameAliasPath(candidate, real) {
   const candidateParts = canonical(candidate).split(/[\\/]+/);
   const realParts = canonical(real).split(/[\\/]+/);
   if (candidateParts.length !== realParts.length) return false;
-  return candidateParts.every((part, index) => part === realParts[index]
-    || hasWindowsShortNameSegment(part)
-    || hasWindowsShortNameSegment(realParts[index]));
+  return candidateParts.every((part, index) => {
+    const realPart = realParts[index];
+    if (part === realPart) return true;
+    // A real 8.3 alias changes exactly one side of a path segment. Requiring
+    // the other side to be the long form prevents an unrelated mismatch from
+    // being hidden by a short-name segment elsewhere in the path.
+    return isWindowsShortNameSegment(part) !== isWindowsShortNameSegment(realPart);
+  });
 }
 
 function hasReparseAncestor(candidate, stopAt = null) {
@@ -145,6 +148,7 @@ module.exports = {
   isInside,
   protectedRoots,
   defaultMutationRoots,
+  isWindowsShortNameAliasPath,
   hasReparseAncestor,
   isProtectedPath,
   assessMutation,

--- a/src/core/pathSafety.js
+++ b/src/core/pathSafety.js
@@ -59,6 +59,22 @@ function defaultMutationRoots() {
   ]);
 }
 
+function hasWindowsShortNameSegment(value) {
+  return String(value || '')
+    .split(/[\\/]+/)
+    .some((segment) => /^[^\\/:*?"<>|]{1,6}~\d(?:\..*)?$/i.test(segment));
+}
+
+function isWindowsShortNameAliasPath(candidate, real) {
+  if (process.platform !== 'win32') return false;
+  const candidateParts = canonical(candidate).split(/[\\/]+/);
+  const realParts = canonical(real).split(/[\\/]+/);
+  if (candidateParts.length !== realParts.length) return false;
+  return candidateParts.every((part, index) => part === realParts[index]
+    || hasWindowsShortNameSegment(part)
+    || hasWindowsShortNameSegment(realParts[index]));
+}
+
 function hasReparseAncestor(candidate, stopAt = null) {
   let current = path.resolve(candidate);
   const stop = stopAt ? path.resolve(stopAt) : path.parse(current).root;
@@ -67,7 +83,7 @@ function hasReparseAncestor(candidate, stopAt = null) {
       const stat = fs.lstatSync(current);
       if (stat.isSymbolicLink()) return true;
       const real = fs.realpathSync.native ? fs.realpathSync.native(current) : fs.realpathSync(current);
-      if (canonical(real) !== canonical(current)) return true;
+      if (canonical(real) !== canonical(current) && !isWindowsShortNameAliasPath(current, real)) return true;
     } catch (err) {
       if (err.code !== 'ENOENT') return true;
     }
@@ -135,4 +151,3 @@ module.exports = {
   captureSnapshot,
   verifySnapshot
 };
-

--- a/tests/pathSafety.test.js
+++ b/tests/pathSafety.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const { hasReparseAncestor } = require('../src/core/pathSafety');
+
+it('does not treat Windows 8.3 aliases as reparse ancestors', () => {
+  const originalPlatform = process.platform;
+  const originalLstatSync = fs.lstatSync;
+  const originalRealpathNative = fs.realpathSync.native;
+  const originalRealpath = fs.realpathSync;
+
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  fs.lstatSync = () => ({ isSymbolicLink: () => false });
+  fs.realpathSync.native = (target) => String(target).replace('RUNNER~1', 'runneradmin');
+  fs.realpathSync = (target) => String(target).replace('RUNNER~1', 'runneradmin');
+
+  try {
+    const result = hasReparseAncestor('/tmp/RUNNER~1/workspace/folder', '/tmp/RUNNER~1/workspace');
+    assert.equal(result, false);
+  } finally {
+    fs.lstatSync = originalLstatSync;
+    fs.realpathSync.native = originalRealpathNative;
+    fs.realpathSync = originalRealpath;
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  }
+});
+
+it('still flags realpath mismatches without short-name aliases', () => {
+  const originalPlatform = process.platform;
+  const originalLstatSync = fs.lstatSync;
+  const originalRealpathNative = fs.realpathSync.native;
+  const originalRealpath = fs.realpathSync;
+
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  fs.lstatSync = () => ({ isSymbolicLink: () => false });
+  fs.realpathSync.native = (target) => String(target).replace('/tmp/workspace', '/tmp/linked-target');
+  fs.realpathSync = (target) => String(target).replace('/tmp/workspace', '/tmp/linked-target');
+
+  try {
+    const result = hasReparseAncestor('/tmp/workspace/folder', '/tmp/workspace');
+    assert.equal(result, true);
+  } finally {
+    fs.lstatSync = originalLstatSync;
+    fs.realpathSync.native = originalRealpathNative;
+    fs.realpathSync = originalRealpath;
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  }
+});

--- a/tests/pathSafety.test.js
+++ b/tests/pathSafety.test.js
@@ -3,7 +3,7 @@
 const { it } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
-const { hasReparseAncestor } = require('../src/core/pathSafety');
+const { hasReparseAncestor, isWindowsShortNameAliasPath } = require('../src/core/pathSafety');
 
 it('does not treat Windows 8.3 aliases as reparse ancestors', () => {
   const originalPlatform = process.platform;
@@ -35,8 +35,8 @@ it('still flags realpath mismatches without short-name aliases', () => {
 
   Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
   fs.lstatSync = () => ({ isSymbolicLink: () => false });
-  fs.realpathSync.native = (target) => String(target).replace('/tmp/workspace', '/tmp/linked-target');
-  fs.realpathSync = (target) => String(target).replace('/tmp/workspace', '/tmp/linked-target');
+  fs.realpathSync.native = (target) => String(target).replace(/workspace/gi, 'linked-target');
+  fs.realpathSync = (target) => String(target).replace(/workspace/gi, 'linked-target');
 
   try {
     const result = hasReparseAncestor('/tmp/workspace/folder', '/tmp/workspace');
@@ -45,6 +45,24 @@ it('still flags realpath mismatches without short-name aliases', () => {
     fs.lstatSync = originalLstatSync;
     fs.realpathSync.native = originalRealpathNative;
     fs.realpathSync = originalRealpath;
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  }
+});
+
+it('does not let an alias segment hide an unrelated path mismatch', () => {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+  try {
+    assert.equal(
+      isWindowsShortNameAliasPath('C:\\RUNNER~1\\workspace', 'C:\\runneradmin\\workspace'),
+      true
+    );
+    assert.equal(
+      isWindowsShortNameAliasPath('C:\\RUNNER~1\\workspace', 'C:\\runneradmin\\other'),
+      false
+    );
+  } finally {
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   }
 });


### PR DESCRIPTION
This pull request improves Windows path handling in the `pathSafety` module by adding logic to recognize Windows 8.3 short-name aliases and avoid false positives when checking for reparse ancestors. It introduces new helper functions, updates core logic, and adds targeted tests to ensure correct behavior.

**Windows path alias handling improvements:**

* Added `isWindowsShortNameSegment` and `isWindowsShortNameAliasPath` helper functions to detect and compare Windows 8.3 short-name path segments, preventing them from being incorrectly flagged as reparse points. (`src/core/pathSafety.js`)
* Updated the `hasReparseAncestor` function to use `isWindowsShortNameAliasPath`, so that short-name aliases are not treated as reparse ancestors if they are the only difference between paths. (`src/core/pathSafety.js`)
* Exported `isWindowsShortNameAliasPath` for use in tests and other modules. (`src/core/pathSafety.js`)

**Testing improvements:**

* Added new tests in `tests/pathSafety.test.js` to verify that Windows 8.3 aliases are handled correctly, including cases where aliases should and should not mask path differences.

closes #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling by recognizing legitimate 8.3 short-name aliases.
  * Prevented valid short-name aliases from being incorrectly flagged as reparse-point ancestors.
  * Continued detecting genuine path mismatches and unrelated discrepancies.

* **Tests**
  * Added coverage for Windows alias handling and mismatch detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->