### PR TITLE
Fix native ci order

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -21,6 +21,8 @@ jobs:
         run: rustup toolchain install 1.85.1-x86_64-pc-windows-msvc --profile minimal --component clippy,rustfmt
       - run: npm ci
       - run: npm run native:check
+      - name: Build native host test artifact
+        run: npm run native-host:build
       - run: npm test
       - run: npm run dist:win
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Verify source and native collector
         run: |
           npm run native:check
+          npm run native-host:build
           npm test
 
       - name: Build Windows installer

--- a/src/core/pathSafety.js
+++ b/src/core/pathSafety.js
@@ -59,10 +59,8 @@ function defaultMutationRoots() {
   ]);
 }
 
-function hasWindowsShortNameSegment(value) {
-  return String(value || '')
-    .split(/[\\/]+/)
-    .some((segment) => /^[^\\/:*?"<>|]{1,6}~\d(?:\..*)?$/i.test(segment));
+function isWindowsShortNameSegment(value) {
+  return /^[^\\/:*?"<>|]{1,6}~\d(?:\..*)?$/i.test(String(value || ''));
 }
 
 function isWindowsShortNameAliasPath(candidate, real) {
@@ -70,9 +68,14 @@ function isWindowsShortNameAliasPath(candidate, real) {
   const candidateParts = canonical(candidate).split(/[\\/]+/);
   const realParts = canonical(real).split(/[\\/]+/);
   if (candidateParts.length !== realParts.length) return false;
-  return candidateParts.every((part, index) => part === realParts[index]
-    || hasWindowsShortNameSegment(part)
-    || hasWindowsShortNameSegment(realParts[index]));
+  return candidateParts.every((part, index) => {
+    const realPart = realParts[index];
+    if (part === realPart) return true;
+    // A real 8.3 alias changes exactly one side of a path segment. Requiring
+    // the other side to be the long form prevents an unrelated mismatch from
+    // being hidden by a short-name segment elsewhere in the path.
+    return isWindowsShortNameSegment(part) !== isWindowsShortNameSegment(realPart);
+  });
 }
 
 function hasReparseAncestor(candidate, stopAt = null) {
@@ -145,6 +148,7 @@ module.exports = {
   isInside,
   protectedRoots,
   defaultMutationRoots,
+  isWindowsShortNameAliasPath,
   hasReparseAncestor,
   isProtectedPath,
   assessMutation,

--- a/src/core/pathSafety.js
+++ b/src/core/pathSafety.js
@@ -59,6 +59,22 @@ function defaultMutationRoots() {
   ]);
 }
 
+function hasWindowsShortNameSegment(value) {
+  return String(value || '')
+    .split(/[\\/]+/)
+    .some((segment) => /^[^\\/:*?"<>|]{1,6}~\d(?:\..*)?$/i.test(segment));
+}
+
+function isWindowsShortNameAliasPath(candidate, real) {
+  if (process.platform !== 'win32') return false;
+  const candidateParts = canonical(candidate).split(/[\\/]+/);
+  const realParts = canonical(real).split(/[\\/]+/);
+  if (candidateParts.length !== realParts.length) return false;
+  return candidateParts.every((part, index) => part === realParts[index]
+    || hasWindowsShortNameSegment(part)
+    || hasWindowsShortNameSegment(realParts[index]));
+}
+
 function hasReparseAncestor(candidate, stopAt = null) {
   let current = path.resolve(candidate);
   const stop = stopAt ? path.resolve(stopAt) : path.parse(current).root;
@@ -67,7 +83,7 @@ function hasReparseAncestor(candidate, stopAt = null) {
       const stat = fs.lstatSync(current);
       if (stat.isSymbolicLink()) return true;
       const real = fs.realpathSync.native ? fs.realpathSync.native(current) : fs.realpathSync(current);
-      if (canonical(real) !== canonical(current)) return true;
+      if (canonical(real) !== canonical(current) && !isWindowsShortNameAliasPath(current, real)) return true;
     } catch (err) {
       if (err.code !== 'ENOENT') return true;
     }
@@ -135,4 +151,3 @@ module.exports = {
   captureSnapshot,
   verifySnapshot
 };
-

--- a/src/security/FolderWatcher.js
+++ b/src/security/FolderWatcher.js
@@ -25,6 +25,7 @@ class FolderWatcher {
     this.scanEngine = options.scanEngine;
     this.clamEngine = options.clamEngine || null;
     this.notify = options.notify || (() => {});
+    this.watchFactory = options.watchFactory || fs.watch;
     this.debounceMs = options.debounceMs || 1500;
     this.watchDirs = options.watchDirs || FolderWatcher.defaultWatchDirs();
     this._watchers = new Map();
@@ -80,10 +81,18 @@ class FolderWatcher {
     try {
       if (!fs.existsSync(dir)) return;
       if (this._watchers.has(dir)) return;
-      const watcher = fs.watch(dir, { persistent: false }, (eventType, filename) => {
-        if (!filename || !this._running) return;
-        const fullPath = path.join(dir, filename.toString());
-        this._schedule(fullPath);
+      const watcher = this.watchFactory(dir, { persistent: false }, (_eventType, filename) => {
+        // fs.watch callbacks run outside the _watchDir try/catch. Windows can
+        // deliver malformed or late events while a directory is being closed;
+        // never let one of those events terminate the test/app process.
+        try {
+          if (!filename || !this._running) return;
+          const relativePath = Buffer.isBuffer(filename) ? filename.toString('utf8') : String(filename);
+          if (!relativePath || relativePath.includes('\0') || path.isAbsolute(relativePath)) return;
+          this._schedule(path.join(dir, relativePath));
+        } catch (_) {
+          /* ignore malformed or stale watcher events */
+        }
       });
       watcher.on('error', () => {
         try { watcher.close(); } catch (_) {}

--- a/tests/folderWatcher.test.js
+++ b/tests/folderWatcher.test.js
@@ -82,4 +82,23 @@ describe('FolderWatcher', () => {
     assert.equal(scanned.length, 0);
     assert.equal(watcher.getStatus().queued, 1);
   });
+
+  it('contains errors from late or malformed watcher events', () => {
+    let onEvent;
+    const fakeWatcher = { on() { return this; }, close() {} };
+    const guarded = new FolderWatcher({
+      watchDirs: [tmp],
+      watchFactory(_dir, _options, callback) {
+        onEvent = callback;
+        return fakeWatcher;
+      },
+      scanEngine: { async runCustomScan() { return {}; } }
+    });
+    guarded.start();
+    guarded._schedule = () => { throw new Error('stale watcher event'); };
+    assert.doesNotThrow(() => onEvent('rename', Buffer.from('payload.bin')));
+    assert.doesNotThrow(() => onEvent('rename', 'C:\\outside\\payload.bin'));
+    assert.doesNotThrow(() => onEvent('rename', 'bad\0name'));
+    guarded.stop();
+  });
 });

--- a/tests/pathSafety.test.js
+++ b/tests/pathSafety.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const { hasReparseAncestor } = require('../src/core/pathSafety');
+
+it('does not treat Windows 8.3 aliases as reparse ancestors', () => {
+  const originalPlatform = process.platform;
+  const originalLstatSync = fs.lstatSync;
+  const originalRealpathNative = fs.realpathSync.native;
+  const originalRealpath = fs.realpathSync;
+
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  fs.lstatSync = () => ({ isSymbolicLink: () => false });
+  fs.realpathSync.native = (target) => String(target).replace('RUNNER~1', 'runneradmin');
+  fs.realpathSync = (target) => String(target).replace('RUNNER~1', 'runneradmin');
+
+  try {
+    const result = hasReparseAncestor('/tmp/RUNNER~1/workspace/folder', '/tmp/RUNNER~1/workspace');
+    assert.equal(result, false);
+  } finally {
+    fs.lstatSync = originalLstatSync;
+    fs.realpathSync.native = originalRealpathNative;
+    fs.realpathSync = originalRealpath;
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  }
+});
+
+it('still flags realpath mismatches without short-name aliases', () => {
+  const originalPlatform = process.platform;
+  const originalLstatSync = fs.lstatSync;
+  const originalRealpathNative = fs.realpathSync.native;
+  const originalRealpath = fs.realpathSync;
+
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  fs.lstatSync = () => ({ isSymbolicLink: () => false });
+  fs.realpathSync.native = (target) => String(target).replace('/tmp/workspace', '/tmp/linked-target');
+  fs.realpathSync = (target) => String(target).replace('/tmp/workspace', '/tmp/linked-target');
+
+  try {
+    const result = hasReparseAncestor('/tmp/workspace/folder', '/tmp/workspace');
+    assert.equal(result, true);
+  } finally {
+    fs.lstatSync = originalLstatSync;
+    fs.realpathSync.native = originalRealpathNative;
+    fs.realpathSync = originalRealpath;
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  }
+});

--- a/tests/pathSafety.test.js
+++ b/tests/pathSafety.test.js
@@ -3,7 +3,7 @@
 const { it } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
-const { hasReparseAncestor } = require('../src/core/pathSafety');
+const { hasReparseAncestor, isWindowsShortNameAliasPath } = require('../src/core/pathSafety');
 
 it('does not treat Windows 8.3 aliases as reparse ancestors', () => {
   const originalPlatform = process.platform;
@@ -35,8 +35,8 @@ it('still flags realpath mismatches without short-name aliases', () => {
 
   Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
   fs.lstatSync = () => ({ isSymbolicLink: () => false });
-  fs.realpathSync.native = (target) => String(target).replace('/tmp/workspace', '/tmp/linked-target');
-  fs.realpathSync = (target) => String(target).replace('/tmp/workspace', '/tmp/linked-target');
+  fs.realpathSync.native = (target) => String(target).replace(/workspace/gi, 'linked-target');
+  fs.realpathSync = (target) => String(target).replace(/workspace/gi, 'linked-target');
 
   try {
     const result = hasReparseAncestor('/tmp/workspace/folder', '/tmp/workspace');
@@ -45,6 +45,24 @@ it('still flags realpath mismatches without short-name aliases', () => {
     fs.lstatSync = originalLstatSync;
     fs.realpathSync.native = originalRealpathNative;
     fs.realpathSync = originalRealpath;
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  }
+});
+
+it('does not let an alias segment hide an unrelated path mismatch', () => {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+  try {
+    assert.equal(
+      isWindowsShortNameAliasPath('C:\\RUNNER~1\\workspace', 'C:\\runneradmin\\workspace'),
+      true
+    );
+    assert.equal(
+      isWindowsShortNameAliasPath('C:\\RUNNER~1\\workspace', 'C:\\runneradmin\\other'),
+      false
+    );
+  } finally {
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   }
 });


### PR DESCRIPTION
This pull request introduces improvements to Windows path handling and error resilience in directory watching, along with related test coverage and minor CI workflow updates. The main focus is on ensuring that Windows 8.3 short name aliases are not incorrectly flagged as symbolic links or reparse points, and on making the folder watcher more robust against malformed or late events.

**Windows path handling improvements:**

* Added `isWindowsShortNameAliasPath` and `isWindowsShortNameSegment` functions to `src/core/pathSafety.js` to accurately detect Windows 8.3 short name path segments and treat them as valid aliases rather than reparse ancestors. This prevents false positives when checking for symbolic links or reparse points on Windows. [[1]](diffhunk://#diff-af460b09bf3a7c27736b863654192aadc3f2138fb82cc3e8633bbabe900203dcR62-R80) [[2]](diffhunk://#diff-af460b09bf3a7c27736b863654192aadc3f2138fb82cc3e8633bbabe900203dcL70-R89)
* Updated `hasReparseAncestor` to use the new alias detection logic, so legitimate 8.3 aliases are not incorrectly flagged as unsafe.
* Exported `isWindowsShortNameAliasPath` for external use.
* Added comprehensive tests for these behaviors in `tests/pathSafety.test.js`.

**FolderWatcher robustness improvements:**

* Updated `FolderWatcher` in `src/security/FolderWatcher.js` to accept a `watchFactory` for easier testing, and improved the event handler to safely ignore malformed, late, or absolute path events, preventing them from crashing the process. [[1]](diffhunk://#diff-da01faae9e34f2eded94794778ed8b9c81941b7919afdaa6c702748538750c63R28) [[2]](diffhunk://#diff-da01faae9e34f2eded94794778ed8b9c81941b7919afdaa6c702748538750c63L83-R95)
* Added tests to ensure that malformed or late watcher events do not throw errors.

**CI workflow updates:**

* Added `npm run native-host:build` to the Windows build and release steps in `.github/workflows/build-all.yml` and `.github/workflows/release.yml` to ensure native host artifacts are built and tested. [[1]](diffhunk://#diff-7682a9fd2942d8a81f55c30abd512b277b1b1eb7c5f16b2c4d88323de90e55d0R24-R25) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R34)