### PR TITLE
Fix startup scripts forcing GPU acceleration off

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "node": ">=26"
   },
   "scripts": {
-    "start": "electron . --disable-logging --disable-gpu --disable-gpu-compositing --disable-gpu-shader-disk-cache --disable-software-rasterizer --disable-background-networking --disable-features=NetworkService,AutofillServerCommunication,AutofillAcrossForms,Autofill --disk-cache-dir=.cache/soterios",
-    "dev": "electron . --dev --disable-logging --disable-gpu --disable-gpu-compositing --disable-gpu-shader-disk-cache --disable-software-rasterizer --disable-background-networking --disable-features=NetworkService,AutofillServerCommunication,AutofillAcrossForms,Autofill --disk-cache-dir=.cache/soterios",
+    "start": "electron . --disable-logging --disable-gpu-shader-disk-cache --disable-background-networking --disable-features=NetworkService,AutofillServerCommunication,AutofillAcrossForms,Autofill --disk-cache-dir=.cache/soterios",
+    "dev": "electron . --dev --disable-logging --disable-gpu-shader-disk-cache --disable-background-networking --disable-features=NetworkService,AutofillServerCommunication,AutofillAcrossForms,Autofill --disk-cache-dir=.cache/soterios",
     "pack": "npm run extension:build && npm run native-host:build && npm run native:process && electron-builder --dir",
     "dist": "npm run extension:build && npm run native-host:build && npm run native:process && electron-builder --publish never",
     "dist:win": "npm run extension:build && npm run native-host:build && npm run native:process && electron-builder --win --publish never",


### PR DESCRIPTION
## Summary
Remove `--disable-gpu`, `--disable-gpu-compositing`, and `--disable-software-rasterizer` from both npm launch scripts. The existing main-process `SOTERIOS_DISABLE_GPU=1` branch remains the opt-in fallback. All other launch tokens, including privacy/cache switches and dev mode, are preserved.

Closes #112. README's existing documentation remains accurate; package.json is the only changed file.

## Testing
- Reproduced the original forced-GPU flags with a failing assertion.
- Exact before/after token comparisons pass for both scripts.
- Executed the actual main-process startup block with a mock Electron app API for unset, `0`, and `1` environment values; all three disable switches appear only for `1`.
- `git diff --check` passes.
- `npm test` was attempted on macOS. Its Node suite encountered platform/sandbox failures and a stalled local-HTTP test. Retried with an isolated test home and a 30-second test timeout: 641 passed, 20 failed, 9 cancelled, 1 skipped. Failures include local socket restrictions, Windows-specific expectations, and process-cleanup assumptions.
- Jest suites run separately with an isolated test home: **49 passed** across all three suites.

Native Electron startup and Windows runtime verification remain unperformed; the mocked startup check is not a native-app launch claim. Dependency install scripts were skipped locally to avoid the unrelated ClamAV download. No dependency versions or lockfiles changed.

AI-assisted with Codex; no independent human-review claim.