### PR TITLE
fix: make root license GitHub-detectable as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-SOTERIOS - LICENSE AGREEMENT
-
 MIT License
 
 Copyright (c) 2026 Christopher Rivera
@@ -22,16 +20,3 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
----
-
-ABOUT THIS APPLICATION
-
-Soterios is a local-first Windows security and maintenance application with
-ClamAV-backed file scanning, process inspection, Windows audit checks,
-firewall visibility, password tools, reports, quarantine, real-time
-protection, and maintenance scripts.
-
-Soterios does not collect telemetry or analytics. Local scanning and system
-analysis happen on your own machine. Network calls are limited to actions
-you request, such as ClamAV definition updates, HIBP k-anonymity password
-checks, or XposedOrNot email breach checks.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,6 @@ Even small improvements, bug reports, or suggestions are appreciated.
 
 ## License
 
-Soterios is released under the [MIT License](build/LICENSE.txt).
+Soterios is released under the [MIT License](LICENSE).
 
 **Copyright © 2026 Christopher Rivera**

--- a/build/LICENSE.txt
+++ b/build/LICENSE.txt
@@ -1,5 +1,3 @@
-SOTERIOS - LICENSE AGREEMENT
-
 MIT License
 
 Copyright (c) 2026 Christopher Rivera
@@ -22,16 +20,3 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
----
-
-ABOUT THIS APPLICATION
-
-Soterios is a local-first Windows security and maintenance application with
-ClamAV-backed file scanning, process inspection, Windows audit checks,
-firewall visibility, password tools, reports, quarantine, real-time
-protection, and maintenance scripts.
-
-Soterios does not collect telemetry or analytics. Local scanning and system
-analysis happen on your own machine. Network calls are limited to actions
-you request, such as ClamAV definition updates, HIBP k-anonymity password
-checks, or XposedOrNot email breach checks.


### PR DESCRIPTION
Fixes #114

- Restore the canonical MIT license text in the root LICENSE file
- Update the README license link to point to LICENSE
- Keep the package.json MIT license declaration unchanged
- Keep the application description in the README
- No new licensing terms introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the repository license files to contain only the standard MIT License text and copyright notice.
  - Removed the application title and supplementary section describing features and privacy behavior from the license materials.
  - Updated the README license link to point to the repository’s root license file instead of the build output license file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->