### PR TITLE
Avoid hard-coded release versions in README download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Download the latest Windows release:
 
 | Platform | Installer | Notes |
 |----------|-----------|-------|
-| **Windows** | `Soterios-Setup-1.3.0.exe` | NSIS installer · requires admin for system-level checks |
+| **Windows** | [Latest release](https://github.com/chrisriv10/Soterios/releases/latest) | NSIS installer · requires admin for system-level checks |
 
 The release build also produces `soterios-extension-2.0.0.zip`, a Chromium Manifest V3 package for sideloading or store submission. The extension is included in the desktop installer resources and can also be built independently (see [Build Installers](#build-installers)).
 


### PR DESCRIPTION
## Summary

Updated the README download instructions to avoid hard-coding a specific Soterios installer version.

## Changes

- Replaced the hard-coded `Soterios-Setup-1.3.0.exe` filename with a link to the latest release.
- Kept the existing Windows installer description and download behavior unchanged.
- Removed the version-specific installer reference so the documentation remains valid across future releases.

## Testing

- Verified the README renders correctly.
- Verified the download link points to `/releases/latest`.
- Verified there is no hard-coded version in the Windows installer filename.
- Ran `git diff --check` successfully.
- No source code or unrelated files were modified.

Closes #131