### PR TITLE
fix: bound FolderWatcher scan queue and recent-scan state

### DIFF
--- a/src/security/FolderWatcher.js
+++ b/src/security/FolderWatcher.js
@@ -4,6 +4,9 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const MAX_QUEUE_SIZE = 256;
+const RECENT_SCAN_WINDOW_MS = 60_000;
+
 /**
  * Watches high-risk directories and queues custom scans when files appear
  * or change. Uses Node's fs.watch (no extra dependency).
@@ -42,6 +45,7 @@ class FolderWatcher {
     this._draining = false;
     this._running = false;
     this._scannedRecently = new Map();
+    this._droppedQueueJobs = 0;
   }
 
   static defaultWatchDirs() {
@@ -60,7 +64,8 @@ class FolderWatcher {
     return {
       running: this._running,
       watched: [...this._watchers.keys()],
-      queued: this._queue.length
+      queued: this._queue.length,
+      dropped: this._droppedQueueJobs
     };
   }
 
@@ -117,6 +122,14 @@ class FolderWatcher {
     this._pending.set(filePath, timer);
   }
 
+  _pruneRecentScans(now = Date.now()) {
+    for (const [filePath, timestamp] of this._scannedRecently) {
+      if (now - timestamp >= RECENT_SCAN_WINDOW_MS) {
+        this._scannedRecently.delete(filePath);
+      }
+    }
+  }
+
   _enqueue(filePath) {
     try {
       const st = fs.statSync(filePath);
@@ -124,9 +137,21 @@ class FolderWatcher {
     } catch (_) {
       return;
     }
+
+    const now = Date.now();
+    this._pruneRecentScans(now);
+
     const last = this._scannedRecently.get(filePath) || 0;
-    if (Date.now() - last < 60_000) return;
+    if (now - last < RECENT_SCAN_WINDOW_MS) return;
+
     if (this._queue.includes(filePath)) return;
+
+    if (this._queue.length >= MAX_QUEUE_SIZE) {
+      this._droppedQueueJobs++;
+      console.warn(`FolderWatcher scan queue full; dropping ${filePath}`);
+      return;
+    }
+
     this._queue.push(filePath);
     this._drain();
   }

--- a/tests/folderWatcher.test.js
+++ b/tests/folderWatcher.test.js
@@ -147,6 +147,46 @@ describe('FolderWatcher', () => {
     assert.deepEqual(status.watched, [tmp]);
     canonical.stop();
   });
+  it('bounds the scan queue and counts dropped jobs during a burst', () => {
+  watcher.start();
+  watcher.scanEngine.isScanning = true;
+
+  for (let i = 0; i < 1000; i++) {
+    const filePath = path.join(tmp, `burst-${i}.bin`);
+    fs.writeFileSync(filePath, 'x');
+    watcher._enqueue(filePath);
+  }
+
+  assert.equal(watcher.getStatus().queued, 256);
+  assert.equal(watcher.getStatus().dropped, 744);
+  });
+
+  it('expires old recent-scan entries', () => {
+  const oldTime = Date.now() - 61_000;
+  const recentTime = Date.now();
+
+  watcher._scannedRecently.set(
+    path.join(tmp, 'old.bin'),
+    oldTime
+  );
+
+  watcher._scannedRecently.set(
+    path.join(tmp, 'recent.bin'),
+    recentTime
+  );
+
+  watcher._pruneRecentScans();
+
+  assert.equal(
+    watcher._scannedRecently.has(path.join(tmp, 'old.bin')),
+    false
+  );
+
+  assert.equal(
+    watcher._scannedRecently.has(path.join(tmp, 'recent.bin')),
+    true
+  );
+  });
 
   it('skips a directory when its canonical path cannot be resolved', () => {
     let watchCalls = 0;


### PR DESCRIPTION
## Summary

Fixes unbounded growth in `FolderWatcher` scan queue and recent-scan state.

### Changes

- Added a maximum queue size of 256 entries.
- Dropped scan jobs are counted and logged when the queue is full.
- Added expiration of recent-scan entries after the existing 60-second deduplication window.
- Preserved existing duplicate-scan prevention behavior.
- Added tests for large file bursts and recent-scan entry expiration.

## Testing

- `node --test tests/folderWatcher.test.js`
- `node --test tests/realTimeWatcher.test.js`
- `git diff --check`

All relevant tests pass.

## Related Issue

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented excessive folder-scan requests from overwhelming the scan queue by enforcing a maximum queue size.
  * Added visibility into the number of scan jobs dropped when the queue is full.
  * Improved cleanup of outdated scan records to keep status information current.

* **Tests**
  * Added coverage for queue limits, dropped jobs, and cleanup of older scan records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->