### PR TITLE
docs: allow startup check to be not applicable

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 <!-- Commands run and any manual verification. -->
 
 - [ ] `npm test`
-- [ ] Application starts successfully
+- [ ] Application starts successfully (or mark N/A and explain why for documentation-only changes)
 - [ ] Relevant edge cases checked
 - [ ] Relevant tests were added or updated
 


### PR DESCRIPTION
## Summary

Allow documentation-only pull requests to mark the application-start check as not applicable while retaining the normal startup validation option.

## Motivation / related issue

Follow-up to #151 and its review feedback.

## What changed

- Added an explicit N/A path with a required explanation to the application-start checklist item.

## Testing

- Focused Node assertion for the rendered checklist text
- `git diff --check`
- Application tests are not applicable to this documentation-only change.

## Screenshots

Not applicable.

## Security and privacy

None.

## Checklist

- [x] This PR is focused on one documentation improvement
- [x] Documentation was updated where necessary
- [x] No secrets or personal data are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the pull request checklist to allow documentation-only changes to mark application startup as not applicable and provide an explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->